### PR TITLE
Fix regex for nick highlighting

### DIFF
--- a/client/libquassel.js
+++ b/client/libquassel.js
@@ -427,7 +427,7 @@ IRCMessage.prototype._updateFlags = function(nick) {
     if (this.type == Type.Plain || this.type == Type.Action) {
         if (nick) {
             var quotedNick = nick.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
-            var regex = new RegExp("([\\W\\D]|^)"+quotedNick+"([\\W\\D]|$)", "i");
+            var regex = new RegExp("([\\W]|^)"+quotedNick+"([\\W]|$)", "i");
             if (regex.test(this.content)) {
                 this.flags = this.flags | Flag.Highlight;
             }


### PR DESCRIPTION
The highlighting regex was using `[\W\D]` which would match any non-word
char or any non-digit char. So single letter additions to a nick would
be highlighted, too.

Example:
nick = mark
highlighted phrases: mark, marks, smarktdfs

We basically want it to match at a word boundary. Since the word
boundary is implemented as `(^\w|\w$|\W\w|\w\W)` that won't work with
Unicode nicks or any nicks using non word chars like \`. So we can't use
`\b` but have to use only `\W`. That will still missmatch Unicode nicks as
part of longer Unicode sequences, but that's a limitation with regexes
in Javascript, not a regression.