### PR TITLE
Fixed className/functionName scopes.

### DIFF
--- a/lib/libquassel.js
+++ b/lib/libquassel.js
@@ -177,10 +177,10 @@ Quassel.prototype.createBuffer = function(networkId, name, bufferId) {
 };
     
 Quassel.prototype.handleStruct = function(obj) {
-    var className = obj[1].toString();
     var self = this;
     switch (obj[0]) {
         case RequestType.Sync:
+            var className = obj[1].toString();
             var functionName = obj[3].toString();
             self.log(className + " received : " + functionName);
             switch(className) {
@@ -478,7 +478,8 @@ Quassel.prototype.handleStruct = function(obj) {
             }
             break;
         case RequestType.RpcCall:
-            switch(className) {
+            var functionName = obj[1].toString();
+            switch(functionName) {
                 case "2displayMsg(Message)":
                     var message = obj[2];
                     var networkId = message.bufferInfo.network;
@@ -511,7 +512,8 @@ Quassel.prototype.handleStruct = function(obj) {
                     }
                     break;
                 case "__objectRenamed__":
-                    switch(functionName) {
+                    var className = obj[2].toString();
+                    switch(className) {
                         case "IrcUser":
                             var newNick = splitOnce(obj[3], "/"); // 1/Nick
                             var oldNick = splitOnce(obj[4], "/"); // 1/Nick_
@@ -519,7 +521,7 @@ Quassel.prototype.handleStruct = function(obj) {
                             self.emit("network.userrenamed", newNick[0], oldNick[1], newNick[1]);
                             break;
                         default:
-                            self.log('Unhandled RpcCall.__objectRenamed__ ' + functionName);
+                            self.log('Unhandled RpcCall.__objectRenamed__ ' + className);
                     }
                     break;
                 case "2networkCreated(NetworkId)":
@@ -538,6 +540,7 @@ Quassel.prototype.handleStruct = function(obj) {
             }
             break;
         case RequestType.InitData:
+            var className = obj[1].toString();
             switch(className) {
                 case "Network":
                     var network = self.handleInitDataNetwork(obj);
@@ -658,7 +661,6 @@ Quassel.prototype.handleStruct = function(obj) {
         default:
             self.log('Unhandled RequestType ' + obj[0]);
     }
-    self.log(obj[0] + " - Special structure : " + className);
 };
 
 Quassel.prototype.dispatch = function(obj) {

--- a/lib/network.js
+++ b/lib/network.js
@@ -124,7 +124,9 @@ Network.prototype.setMyNick = function(nick) {
  */
 Network.prototype.renameUser = function(oldNick, newNick) {
     var user = this.getUserByNick(oldNick);
-    user.nick = newNick;
+    if (user !== null) {
+        user.nick = newNick;
+    } 
     this.nickUserMap[newNick] = user;
     delete this.nickUserMap[oldNick];
 };


### PR DESCRIPTION
I fixed an issue with className and functionName variables in handleScruct.
`__objectRenamed__` wasn't always working because functionName is only set in the `RequestType.Sync` code, but was also used in `RequestType.RpcCall`. Also `obj[1]` in `RpcCall` is the function name, not the class name. The class name is stored in `obj[2]` (e.g. "IrcUser" is the class, not a function).